### PR TITLE
sctp-tests: break once st_init_param return err

### DIFF
--- a/libst/system.sh
+++ b/libst/system.sh
@@ -16,8 +16,17 @@ st_lksctp_setup()
 	st_env_popd
 }
 
+st_libtool_setup()
+{
+	[ -a /usr/bin/libtool ] && return 0
+
+	st_log ERR "no libtool found"
+	return 1
+}
+
 st_package_setup()
 {
+	st_libtool_setup || return 1
 	set -x
 	st_lksctp_setup
 	set +x

--- a/sctp-tests
+++ b/sctp-tests
@@ -196,7 +196,7 @@ st_init_param()
 st_check_pack()
 {
 	st_load_libst "system" || return 1
-	st_package_setup >> $Output 2>&1
+	st_package_setup >> $Output 2>&1 || return 1
 	st_log DBG "check and install package done !"
 }
 
@@ -324,7 +324,7 @@ sctp_tests()
 		;;
 
 	run)
-		st_do_init
+		st_do_init || return 1
 		st_case_schedule
 		;;
 	shell)


### PR DESCRIPTION
This patch is mostly used to check libtool before compiling
lksctp-tools, return and log err if no libtool is found. It
just leaves it to users to setup libtool, as different distros
have different commands to install it.

Signed-off-by: Xin Long <lucien.xin@gmail.com>