### PR TITLE
testcase: add a regression case peeloffbusy

### DIFF
--- a/testcase/regression/peeloffbusy/client.c
+++ b/testcase/regression/peeloffbusy/client.c
@@ -1,0 +1,104 @@
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <linux/sctp.h>
+#include <arpa/inet.h>
+#include <sys/types.h>
+#include <pthread.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <errno.h>
+#include <netdb.h>
+
+#define PPID            1234
+
+static int pass = 1;
+
+static int get_asoc_id(int fd)
+{
+	int len = (1 * sizeof(sctp_assoc_t)) + sizeof(uint32_t);
+	char *buf = (char *)malloc(len);
+
+	if (getsockopt(fd, IPPROTO_SCTP, SCTP_GET_ASSOC_ID_LIST,
+	    (void *)buf, &len) < 0) {
+		perror("getsockopt");
+		exit(-1);
+	}
+
+	return ((struct sctp_assoc_ids *)buf)->gaids_assoc_id[0];
+}
+
+void *peeloff_sctp(void *args)
+{
+	int sctpsd = (long long)args;
+	sctp_peeloff_arg_t peeloff;
+	int optlen, newsd, associd;
+
+	associd = get_asoc_id(sctpsd);
+	sleep(5);
+	printf("sd is %d, %d\n", sctpsd, associd);
+
+	peeloff.associd = associd;
+	optlen = sizeof(peeloff);
+
+	newsd = getsockopt(sctpsd, IPPROTO_SCTP, SCTP_SOCKOPT_PEELOFF,
+			   &peeloff, &optlen);
+	if (errno != EBUSY)
+		pass = 0;
+
+	printf("new sd %d\n", newsd);
+	system("iptables -F");
+
+	return NULL;
+}
+
+int main(int argc, char **argv)
+{
+	struct sctp_initmsg initmsg = {0};
+	struct sockaddr_in servaddr = {0};
+	struct sctp_status status = {0};
+	struct addrinfo *remote_info;
+	char a[1024] = "1024";
+	socklen_t opt_len;
+	pthread_t peel;
+	int sctpsd, i;
+
+	/* get the arguments */
+	bzero((void *)&servaddr, sizeof(servaddr));
+	if (getaddrinfo(argv[1], argv[2], NULL, &remote_info) != 0) {
+		perror("getaddrinfo");
+		exit(-1);
+	}
+	memcpy(&servaddr, remote_info->ai_addr, remote_info->ai_addrlen);
+	printf("Starting SCTP client connection to %s:%s\n", argv[1], argv[2]);
+
+	sctpsd = socket(AF_INET, SOCK_SEQPACKET, IPPROTO_SCTP);
+	printf("socket created...\n");
+
+	/* set the association options */
+	initmsg.sinit_num_ostreams = 1;
+	setsockopt(sctpsd, IPPROTO_SCTP, SCTP_INITMSG, &initmsg,
+		   sizeof(initmsg));
+	printf("setsockopt succeeded...\n");
+
+	connect(sctpsd, (struct sockaddr *)&servaddr, sizeof(servaddr));
+	printf("connect succeeded...\n");
+
+	/* check status */
+	opt_len = (socklen_t)sizeof(status);
+	getsockopt(sctpsd, IPPROTO_SCTP, SCTP_STATUS, &status, &opt_len);
+
+	pthread_create(&peel, NULL, peeloff_sctp, (void *)(long long)sctpsd);
+	system("iptables -A OUTPUT -p sctp --chunk-types any DATA -j DROP");
+
+	for (i = 0; i < 100; i++)
+		sctp_sendmsg(sctpsd, (const void *)a, sizeof(a), &servaddr,
+			     sizeof(servaddr), htonl(PPID), 0, 0, 0, 0);
+
+	pthread_join(peel, NULL);
+
+	close(sctpsd);
+
+	return !pass;
+}

--- a/testcase/regression/peeloffbusy/issue
+++ b/testcase/regression/peeloffbusy/issue
@@ -1,0 +1,5 @@
+commit dfcb9f4f99f1e9a49e43398a7bfbf56927544af1
+Author: Marcelo Ricardo Leitner <marcelo.leitner@gmail.com>
+Date:   Thu Feb 23 09:31:18 2017 -0300
+
+    sctp: deny peeloff operation on asocs with threads sleeping on it

--- a/testcase/regression/peeloffbusy/test.sh
+++ b/testcase/regression/peeloffbusy/test.sh
@@ -1,0 +1,26 @@
+Name="peeloffbusy"
+
+do_setup()
+{
+	sctp_darn -H 127.0.0.1 -P 5001 -l > /dev/null 2>&1 &
+	sctp_darn_pid=$!
+	gcc client.c -o client -lsctp -lpthread
+}
+
+do_clean()
+{
+	local logf="$(st_o).log"
+
+	kill $sctp_darn_pid
+	rm client $logf -rf
+}
+
+do_test()
+{
+	local logf="$(st_o).log"
+	local res=PASS
+
+	./client 127.0.0.1 5001 > $logf 2>&1 || res=FAIL
+
+	st_log INFO "- $res -"
+}

--- a/testplan/upstream.list
+++ b/testplan/upstream.list
@@ -7,5 +7,6 @@ testcase/performance/repeatability/sctp_stream~on_sit.sh
 testcase/stress/procdumps/test.sh
 testcase/stress/sctpdiag/test.sh
 testcase/regression/gsomtuchange/test.sh
+testcase/regression/peeloffbusy/test.sh
 testcase/performance/sctphashtable/test~on_netns.sh
 testcase/performance/sctphashtable/test~on_team.sh


### PR DESCRIPTION
This is a test case for denying peeloff operation on asocs with
threads sleeping on it.

Signed-off-by: Xin Long <lucien.xin@gmail.com>