### PR TITLE
sctp-tests: auto-load multiple tests from a folder

### DIFF
--- a/sctp-tests
+++ b/sctp-tests
@@ -68,11 +68,19 @@ st_case_validate()
 st_parse_testcase()
 {
 	local path=$TestCase
-
+	local t
+	local t_
 
 	[ -d "$path" ] && {
-		echo "$path/test.sh"
-		return 0;
+		if [ -x "$path/test.sh" ]; then
+			echo "$path/test.sh"
+			return 0
+		fi
+		for t in "$path"/*.sh; do
+			t_=${t##*/}
+			[ "${t_:0:3}" != "lib" ] && echo "$t"
+		done
+		return 0
 	}
 
 	[ ${path:0-4} = "list" ] && {


### PR DESCRIPTION
Currently, it either execute test.sh test or you need to specify a
testplan including multiple tests in the same folder.

With this patch, if test.sh is not there, it will execute the tests that
doesn't start with 'lib'.

Signed-off-by: Marcelo Ricardo Leitner <marcelo.leitner@gmail.com>