### PR TITLE
testcase: fix peeloffbusy case

### DIFF
--- a/testcase/regression/peeloffbusy/client.c
+++ b/testcase/regression/peeloffbusy/client.c
@@ -1,19 +1,13 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <linux/sctp.h>
-#include <arpa/inet.h>
-#include <sys/types.h>
-#include <pthread.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 #include <stdio.h>
 #include <errno.h>
 #include <netdb.h>
-
-#define PPID            1234
-
-static int pass = 1;
+#include <signal.h>
 
 static int get_asoc_id(int fd)
 {
@@ -21,84 +15,80 @@ static int get_asoc_id(int fd)
 	char *buf = (char *)malloc(len);
 
 	if (getsockopt(fd, IPPROTO_SCTP, SCTP_GET_ASSOC_ID_LIST,
-	    (void *)buf, &len) < 0) {
+	    (void *)buf, &len) == -1) {
 		perror("getsockopt");
-		exit(-1);
+		return 0;
 	}
 
 	return ((struct sctp_assoc_ids *)buf)->gaids_assoc_id[0];
 }
 
-void *peeloff_sctp(void *args)
+static void *peeloff_sctp(void *args)
 {
 	int sctpsd = (long long)args;
 	sctp_peeloff_arg_t peeloff;
 	int optlen, newsd, associd;
 
 	associd = get_asoc_id(sctpsd);
-	sleep(5);
 	printf("sd is %d, %d\n", sctpsd, associd);
+	if (!associd)
+		goto out;
 
+	sleep(5);
 	peeloff.associd = associd;
 	optlen = sizeof(peeloff);
 
 	newsd = getsockopt(sctpsd, IPPROTO_SCTP, SCTP_SOCKOPT_PEELOFF,
 			   &peeloff, &optlen);
-	if (errno != EBUSY)
-		pass = 0;
-
 	printf("new sd %d\n", newsd);
-	system("iptables -F");
+	if (newsd == -1)
+		perror("getsockopt");
 
+out:
+	system("iptables -F");
 	return NULL;
 }
 
 int main(int argc, char **argv)
 {
-	struct sctp_initmsg initmsg = {0};
-	struct sockaddr_in servaddr = {0};
-	struct sctp_status status = {0};
 	struct addrinfo *remote_info;
-	char a[1024] = "1024";
-	socklen_t opt_len;
+	struct sockaddr_in servaddr;
+	char a[1024] = "hello";
+	int sctpsd, i, err;
 	pthread_t peel;
-	int sctpsd, i;
+	int pass = 0;
 
-	/* get the arguments */
+	signal(SIGPIPE, SIG_IGN);
 	bzero((void *)&servaddr, sizeof(servaddr));
-	if (getaddrinfo(argv[1], argv[2], NULL, &remote_info) != 0) {
+
+	err = getaddrinfo(argv[1], argv[2], NULL, &remote_info);
+	if (err) {
 		perror("getaddrinfo");
-		exit(-1);
+		return !pass;
 	}
 	memcpy(&servaddr, remote_info->ai_addr, remote_info->ai_addrlen);
 	printf("Starting SCTP client connection to %s:%s\n", argv[1], argv[2]);
 
 	sctpsd = socket(AF_INET, SOCK_SEQPACKET, IPPROTO_SCTP);
-	printf("socket created...\n");
-
-	/* set the association options */
-	initmsg.sinit_num_ostreams = 1;
-	setsockopt(sctpsd, IPPROTO_SCTP, SCTP_INITMSG, &initmsg,
-		   sizeof(initmsg));
-	printf("setsockopt succeeded...\n");
-
-	connect(sctpsd, (struct sockaddr *)&servaddr, sizeof(servaddr));
-	printf("connect succeeded...\n");
-
-	/* check status */
-	opt_len = (socklen_t)sizeof(status);
-	getsockopt(sctpsd, IPPROTO_SCTP, SCTP_STATUS, &status, &opt_len);
+	err = connect(sctpsd, (struct sockaddr *)&servaddr, sizeof(servaddr));
+	if (err == -1) {
+		perror("connect");
+		goto out;
+	}
 
 	pthread_create(&peel, NULL, peeloff_sctp, (void *)(long long)sctpsd);
 	system("iptables -A OUTPUT -p sctp --chunk-types any DATA -j DROP");
-
-	for (i = 0; i < 100; i++)
-		sctp_sendmsg(sctpsd, (const void *)a, sizeof(a), &servaddr,
-			     sizeof(servaddr), htonl(PPID), 0, 0, 0, 0);
-
+	for (i = 0; i < 100; i++) {
+		err = sctp_sendmsg(sctpsd, (const void *)a, sizeof(a),
+				   &servaddr, sizeof(servaddr), 0, 0, 0, 0, 0);
+		if (errno == EPIPE) {
+			pass = 1;
+			break;
+		}
+	}
 	pthread_join(peel, NULL);
 
+out:
 	close(sctpsd);
-
 	return !pass;
 }


### PR DESCRIPTION
On kernel upstream after Commit a0ff660058b8 ("sctp: return error if the
asoc has been peeled off in sctp_wait_for_sndbuf"), peeloff could still
work when sendmsg is in wait_for_sndbuf, and then it would return EPIPE.

So this case should also change accordingly.

Signed-off-by: Xin Long <lucien.xin@gmail.com>